### PR TITLE
Logging 2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ ENV PYTHONPATH /poseidonWork/poseidon:$PYTHONPATH
 RUN find . -name requirements.txt -type f -exec pip install -r {} \;
 
 ENV PYTHONUNBUFFERED 0
+ENV SYS_LOG_HOST NOT_CONFIGURED
+ENV SYS_LOG_PORT 514
 
 # Add Tini
 ENV TINI_VERSION v0.16.1

--- a/config/poseidon.config
+++ b/config/poseidon.config
@@ -1,6 +1,7 @@
 [Monitor]
 config=True
 loggingFile = /poseidonWork/poseidon/config/logging.json
+logger_level = DEBUG
 reinvestigation_frequency =  60
 max_concurrent_reinvestigations = 2 
 scan_frequency = 5

--- a/poseidon/baseClasses/Logger_Base.py
+++ b/poseidon/baseClasses/Logger_Base.py
@@ -44,7 +44,7 @@ class Logger:
 
     # type in the address explicitly . Python doesn't like it if the host is
     # in variable form
-    sys_log = logging.handlers.SysLogHandler(address=('10.179.0.101', port),
+    sys_log = logging.handlers.SysLogHandler(address=(host, port),
                                              socktype=socket.SOCK_STREAM)
     sys_log.setFormatter(formatter)
 

--- a/poseidon/baseClasses/Logger_Base.py
+++ b/poseidon/baseClasses/Logger_Base.py
@@ -40,20 +40,18 @@ class Logger:
     formatter = logging.Formatter('%(asctime)s - %(levelname)s - '
                                   '%(module)s:%(lineno)-3d - %(message)s')
 
-    # have it sent to both stderr and a user defined syslog
+    # set the logger to log to stderr
     sys_err = logging.StreamHandler()
     sys_err.setFormatter(formatter)
     logger.addHandler(sys_err)
 
     # don't try to connect to a syslog address if one was not supplied
     if host != 'NOT_CONFIGURED':
+        # if a syslog address was supplied, log to it
         sys_log = logging.handlers.SysLogHandler(address=(host, port),
                                                  socktype=socket.SOCK_STREAM)
         sys_log.setFormatter(formatter)
         logger.addHandler(sys_log)
-
-    # logger prints twice if this is not set to false
-    #logger.propagate = False
 
     @staticmethod
     def set_level(level):

--- a/poseidon/baseClasses/Logger_Base.py
+++ b/poseidon/baseClasses/Logger_Base.py
@@ -18,6 +18,7 @@
 """
 import logging
 import logging.handlers
+import os
 import socket
 
 
@@ -26,8 +27,8 @@ class Logger:
     Base logger class that handles logging. Outputs to both stderr and a user
     specified syslog. To log, use the class's variable 'logger'
     """
-    host = 'localhost'
-    port = 514
+    host = os.getenv('SYS_LOG_HOST', 'NOT_CONFIGURED')
+    port = int(os.getenv('SYS_LOG_PORT', 514))
 
     level_int = {'CRITICAL': 50, 'ERROR': 40, 'WARNING': 30,
                       'INFO': 20, 'DEBUG' : 10}
@@ -41,16 +42,15 @@ class Logger:
     # have it sent to both stderr and a user defined syslog
     sys_err = logging.StreamHandler()
     sys_err.setFormatter(formatter)
+    logger.addHandler(sys_err)
 
     # type in the address explicitly . Python doesn't like it if the host is
     # in variable form
-    sys_log = logging.handlers.SysLogHandler(address=(host, port),
-                                             socktype=socket.SOCK_STREAM)
-    sys_log.setFormatter(formatter)
-
-    logger.addHandler(sys_err)
-    logger.addHandler(sys_log)
-    sys_log.setFormatter(formatter)
+    if host != 'NOT_CONFIGURED':
+        sys_log = logging.handlers.SysLogHandler(address=(host, port),
+                                                 socktype=socket.SOCK_STREAM)
+        sys_log.setFormatter(formatter)
+        logger.addHandler(sys_log)
 
     # logger prints twice if this is not set to false
     logger.propagate = False

--- a/poseidon/baseClasses/Logger_Base.py
+++ b/poseidon/baseClasses/Logger_Base.py
@@ -26,42 +26,44 @@ class Logger:
     Base logger class that handles logging. Outputs to both stderr and a user
     specified syslog. To log, use the class's variable 'logger'
     """
-    def __init__(self, name):
-        host = 'l0.179.0.101'
-        port = 514
+    host = 'localhost'
+    port = 514
 
-        self.count = 0
-        self.level_int = {'CRITICAL': 50, 'ERROR': 40, 'WARNING': 30,
-                          'INFO': 20, 'DEBUG' : 10}
+    level_int = {'CRITICAL': 50, 'ERROR': 40, 'WARNING': 30,
+                      'INFO': 20, 'DEBUG' : 10}
 
-        self.logger = logging.getLogger(name)
-        self.logger.setLevel(logging.DEBUG)
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.DEBUG)
 
-        formatter = logging.Formatter('%(asctime)s - %(levelname)s - '
-                                      '%(module)s:%(lineno)-3d - %(message)s')
+    formatter = logging.Formatter('%(asctime)s - %(levelname)s - '
+                                  '%(module)s:%(lineno)-3d - %(message)s')
 
-        # have it sent to both stderr and a user defined syslog
-        sys_err = logging.StreamHandler()
-        sys_err.setFormatter(formatter)
+    # have it sent to both stderr and a user defined syslog
+    sys_err = logging.StreamHandler()
+    sys_err.setFormatter(formatter)
 
-        #sys_log = logging.handlers.SysLogHandler(address=(host, port),
-        #                                         socktype=socket.SOCK_STREAM)
-        #sys_log.setFormatter(formatter)
+    # type in the address explicitly . Python doesn't like it if the host is
+    # in variable form
+    sys_log = logging.handlers.SysLogHandler(address=('10.179.0.101', port),
+                                             socktype=socket.SOCK_STREAM)
+    sys_log.setFormatter(formatter)
 
-        self.logger.addHandler(sys_err)
-        #self.logger.addHandler(sys_log)
-        #sys_log.setFormatter(formatter)
+    logger.addHandler(sys_err)
+    logger.addHandler(sys_log)
+    sys_log.setFormatter(formatter)
 
-        # logger prints twice if this is not set to false
-        self.logger.propagate = False
-        
-    def set_level(self, level):
+    # logger prints twice if this is not set to false
+    logger.propagate = False
+
+    @staticmethod
+    def set_level(level):
         """
         Set the logger level. That level and above gets logged.
         """
-        self.logger.setLevel(self.level_int[level.upper()])
+        Logger.logger.setLevel(Logger.level_int[level.upper()])
 
-    def logger_config(self, config):
+    @staticmethod
+    def logger_config(config):
         """
         Load configuration files if they exist for loggers.
         """
@@ -69,10 +71,3 @@ class Logger:
             logging.config.dictConfigClass(config)
         else:
             logging.basicConfig()
-
-    def debug(self, message):
-        if self.count % 10 == 0:
-            self.logger.debug(message)
-            self.count = 1
-        else:
-            self.count += 1

--- a/poseidon/baseClasses/Logger_Base.py
+++ b/poseidon/baseClasses/Logger_Base.py
@@ -36,6 +36,7 @@ class Logger:
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.DEBUG)
 
+    # timestamp - logger_level - class:line number - message
     formatter = logging.Formatter('%(asctime)s - %(levelname)s - '
                                   '%(module)s:%(lineno)-3d - %(message)s')
 
@@ -44,8 +45,7 @@ class Logger:
     sys_err.setFormatter(formatter)
     logger.addHandler(sys_err)
 
-    # type in the address explicitly . Python doesn't like it if the host is
-    # in variable form
+    # don't try to connect to a syslog address if one was not supplied
     if host != 'NOT_CONFIGURED':
         sys_log = logging.handlers.SysLogHandler(address=(host, port),
                                                  socktype=socket.SOCK_STREAM)
@@ -53,7 +53,7 @@ class Logger:
         logger.addHandler(sys_log)
 
     # logger prints twice if this is not set to false
-    logger.propagate = False
+    #logger.propagate = False
 
     @staticmethod
     def set_level(level):

--- a/poseidon/baseClasses/Logger_Base.py
+++ b/poseidon/baseClasses/Logger_Base.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+#
+#   Copyright (c) 2017 In-Q-Tel, Inc, All Rights Reserved.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+""" Created on 18 September 2017
+@author: Jeff Wang
+"""
+import logging
+import logging.handlers
+import socket
+
+
+class Logger:
+    """
+    Base logger class that handles logging. Outputs to both stderr and a user
+    specified syslog. To log, use the class's variable 'logger'
+    """
+    def __init__(self, name):
+        host = 'l0.179.0.101'
+        port = 514
+
+        self.count = 0
+        self.level_int = {'CRITICAL': 50, 'ERROR': 40, 'WARNING': 30,
+                          'INFO': 20, 'DEBUG' : 10}
+
+        self.logger = logging.getLogger(name)
+        self.logger.setLevel(logging.DEBUG)
+
+        formatter = logging.Formatter('%(asctime)s - %(levelname)s - '
+                                      '%(module)s:%(lineno)-3d - %(message)s')
+
+        # have it sent to both stderr and a user defined syslog
+        sys_err = logging.StreamHandler()
+        sys_err.setFormatter(formatter)
+
+        #sys_log = logging.handlers.SysLogHandler(address=(host, port),
+        #                                         socktype=socket.SOCK_STREAM)
+        #sys_log.setFormatter(formatter)
+
+        self.logger.addHandler(sys_err)
+        #self.logger.addHandler(sys_log)
+        #sys_log.setFormatter(formatter)
+
+        # logger prints twice if this is not set to false
+        self.logger.propagate = False
+        
+    def set_level(self, level):
+        """
+        Set the logger level. That level and above gets logged.
+        """
+        self.logger.setLevel(self.level_int[level.upper()])
+
+    def logger_config(self, config):
+        """
+        Load configuration files if they exist for loggers.
+        """
+        if config:
+            logging.config.dictConfigClass(config)
+        else:
+            logging.basicConfig()
+
+    def debug(self, message):
+        if self.count % 10 == 0:
+            self.logger.debug(message)
+            self.count = 1
+        else:
+            self.count += 1

--- a/poseidon/baseClasses/Monitor_Action_Base.py
+++ b/poseidon/baseClasses/Monitor_Action_Base.py
@@ -17,11 +17,12 @@
 Created on 14 Jul 2016
 @author: dgrossman
 """
-import logging
+#import logging
 
+from poseidon.baseClasses.Logger_Base import Logger
 from poseidon.baseClasses.Rock_Bottom import Rock_Bottom
 
-module_logger = logging.getLogger(__name__)
+module_logger = Logger(__name__)
 
 """ Base call stubs
 
@@ -47,7 +48,7 @@ class Monitor_Action_Base(Rock_Bottom):  # pragma: no cover
         """
 
         self.owner = owner
-        self.logger = module_logger
+        self.logger = module_logger.logger
         if self.owner.mod_name is not None:
             self.config_section_name = self.owner.mod_name + ':' + self.mod_name
         else:

--- a/poseidon/baseClasses/Monitor_Action_Base.py
+++ b/poseidon/baseClasses/Monitor_Action_Base.py
@@ -17,12 +17,10 @@
 Created on 14 Jul 2016
 @author: dgrossman
 """
-#import logging
-
 from poseidon.baseClasses.Logger_Base import Logger
 from poseidon.baseClasses.Rock_Bottom import Rock_Bottom
 
-module_logger = Logger(__name__)
+module_logger = Logger
 
 """ Base call stubs
 

--- a/poseidon/baseClasses/Monitor_Helper_Base.py
+++ b/poseidon/baseClasses/Monitor_Helper_Base.py
@@ -17,13 +17,10 @@
 Created on 14 July 2016
 @author: dgrossman
 '''
-#import logging
-
 from poseidon.baseClasses.Logger_Base import Logger
 from poseidon.baseClasses.Rock_Bottom import Rock_Bottom
 
-#module_logger = logging.getLogger(__name__)
-module_logger = Logger(__name__)
+module_logger = Logger
 
 
 class Monitor_Helper_Base(Rock_Bottom):  # pragma: no cover
@@ -42,7 +39,6 @@ class Monitor_Helper_Base(Rock_Bottom):  # pragma: no cover
         if owner.logger is not None:
             self.logger = owner.logger
         else:
-            #self.logger = logging.getLogger(__name__)
             self.logger = module_logger.logger
 
         self.logger.debug('set_owner = {0}'.format(owner.mod_name))

--- a/poseidon/baseClasses/Monitor_Helper_Base.py
+++ b/poseidon/baseClasses/Monitor_Helper_Base.py
@@ -17,11 +17,13 @@
 Created on 14 July 2016
 @author: dgrossman
 '''
-import logging
+#import logging
 
+from poseidon.baseClasses.Logger_Base import Logger
 from poseidon.baseClasses.Rock_Bottom import Rock_Bottom
 
-module_logger = logging.getLogger(__name__)
+#module_logger = logging.getLogger(__name__)
+module_logger = Logger(__name__)
 
 
 class Monitor_Helper_Base(Rock_Bottom):  # pragma: no cover
@@ -40,7 +42,8 @@ class Monitor_Helper_Base(Rock_Bottom):  # pragma: no cover
         if owner.logger is not None:
             self.logger = owner.logger
         else:
-            self.logger = logging.getLogger(__name__)
+            #self.logger = logging.getLogger(__name__)
+            self.logger = module_logger.logger
 
         self.logger.debug('set_owner = {0}'.format(owner.mod_name))
         self.owner = owner
@@ -66,12 +69,12 @@ class Monitor_Helper_Base(Rock_Bottom):  # pragma: no cover
         self.mod_configuration = dict()
         conf = self.owner.owner.Config.get_endpoint('Handle_SectionConfig')
         ostr = '********** conf:{0}'.format(conf)
-        print ostr
+        print(ostr)
         if conf is not None:
             for item in conf.direct_get(self.config_section_name):
                 ostr = '********** item:{0}'.format(item)
                 self.logger.debug(ostr)
-                print ostr
+                print(ostr)
                 k, v = item
                 self.mod_configuration[k] = v
                 ostr = 'config:{0}:{1}'.format(

--- a/poseidon/baseClasses/Rabbit_Base.py
+++ b/poseidon/baseClasses/Rabbit_Base.py
@@ -16,7 +16,6 @@
 ''' Created on 21 August 2017
 @author: dgrossman
 '''
-#import logging
 import pika
 import threading
 import time
@@ -26,8 +25,7 @@ from functools import partial
 from Logger_Base import Logger
 
 
-#module_logger = logging.getLogger(__name__)
-module_logger = Logger(__name__)
+module_logger = Logger
 
 
 class Rabbit_Base(object):

--- a/poseidon/baseClasses/Rabbit_Base.py
+++ b/poseidon/baseClasses/Rabbit_Base.py
@@ -16,26 +16,27 @@
 ''' Created on 21 August 2017
 @author: dgrossman
 '''
-import logging
+#import logging
+import pika
 import threading
 import time
 import types
 from functools import partial
 
-import pika
+from Logger_Base import Logger
 
-module_logger = logging.getLogger(__name__)
+
+#module_logger = logging.getLogger(__name__)
+module_logger = Logger(__name__)
 
 
 class Rabbit_Base(object):
-    '''Comment Goes Here
-
-    Attributes:
-
+    '''
+    Base Class for RabbitMQ
     '''
 
     def __init__(self):
-        self.logger = module_logger
+        self.logger = module_logger.logger
 
     def make_rabbit_connection(self, host, port, exchange, queue_name, keys,
                                total_sleep=float('inf')):  # pragma: no cover

--- a/poseidon/baseClasses/Rock_Bottom.py
+++ b/poseidon/baseClasses/Rock_Bottom.py
@@ -16,9 +16,12 @@
 """ Created on  18 July 2016
 @author: dgrossman
 """
-import logging
+#import logging
 
-module_logger = logging.getLogger(__name__)
+from Logger_Base import Logger
+
+#module_logger = logging.getLogger(__name__)
+module_logger = Logger(__name__).logger
 
 
 class Rock_Bottom(object):

--- a/poseidon/baseClasses/Rock_Bottom.py
+++ b/poseidon/baseClasses/Rock_Bottom.py
@@ -16,12 +16,9 @@
 """ Created on  18 July 2016
 @author: dgrossman
 """
-#import logging
-
 from Logger_Base import Logger
 
-#module_logger = logging.getLogger(__name__)
-module_logger = Logger(__name__).logger
+module_logger = Logger.logger
 
 
 class Rock_Bottom(object):

--- a/poseidon/poseidonMonitor/Config/Config.py
+++ b/poseidon/poseidonMonitor/Config/Config.py
@@ -23,14 +23,14 @@ Created on 17 May 2016
 """
 import ConfigParser
 import json
-import logging
 import os
 
+from poseidon.baseClasses.Logger_Base import Logger
 from poseidon.baseClasses.Monitor_Action_Base import Monitor_Action_Base
 from poseidon.baseClasses.Monitor_Helper_Base import Monitor_Helper_Base
 
 
-module_logger = logging.getLogger(__name__)
+module_logger = Logger(__name__)
 
 # poseidonWork created in docker containers
 config_template_path = '/poseidonWork/config/poseidon.config'
@@ -40,7 +40,7 @@ class Config(Monitor_Action_Base):
 
     def __init__(self):
         super(Config, self).__init__()
-        self.logger = module_logger
+        self.logger = module_logger.logger
         self.CONFIG = None
         self.mod_name = self.__class__.__name__
         self.config_section_name = self.mod_name
@@ -81,7 +81,7 @@ class Handle_FullConfig(Monitor_Helper_Base):
     def __init__(self):
         super(Handle_FullConfig, self).__init__()
         self.mod_name = self.__class__.__name__
-        self.logger = module_logger
+        self.logger = module_logger.logger
 
     def direct_get(self):
         ''' get the config from the owner '''
@@ -136,7 +136,7 @@ class Handle_FieldConfig(Monitor_Helper_Base):
 
     def __init__(self):
         super(Handle_FieldConfig, self).__init__()
-        self.logger = module_logger
+        self.logger = module_logger.logger
         self.mod_name = self.__class__.__name__
 
     def direct_get(self, field, section):

--- a/poseidon/poseidonMonitor/Config/Config.py
+++ b/poseidon/poseidonMonitor/Config/Config.py
@@ -30,7 +30,7 @@ from poseidon.baseClasses.Monitor_Action_Base import Monitor_Action_Base
 from poseidon.baseClasses.Monitor_Helper_Base import Monitor_Helper_Base
 
 
-module_logger = Logger(__name__)
+module_logger = Logger
 
 # poseidonWork created in docker containers
 config_template_path = '/poseidonWork/config/poseidon.config'

--- a/poseidon/poseidonMonitor/Config/test_Config.py
+++ b/poseidon/poseidonMonitor/Config/test_Config.py
@@ -19,13 +19,12 @@ Test module for Config.py
 Created on 28 June 2016
 @author: dgrossman, lanhamt
 """
-import logging
-
 import pytest
 
+from poseidon.baseClasses.Logger_Base import Logger
 from poseidon.poseidonMonitor.Config.Config import config_interface
 
-module_logger = logging.getLogger(__name__)
+module_logger = Logger.logger
 
 
 # exposes the application for testing

--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/NorthBoundControllerAbstraction.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/NorthBoundControllerAbstraction.py
@@ -27,7 +27,7 @@ from poseidon.baseClasses.Monitor_Helper_Base import Monitor_Helper_Base
 from poseidon.poseidonMonitor.NorthBoundControllerAbstraction.proxy.bcf.bcf import \
     BcfProxy
 
-module_logger = Logger(__name__)
+module_logger = Logger
 
 
 class NorthBoundControllerAbstraction(Monitor_Action_Base):

--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/NorthBoundControllerAbstraction.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/NorthBoundControllerAbstraction.py
@@ -18,16 +18,16 @@ Created on 17 May 2016
 '''
 import hashlib
 import json
-import logging
 import Queue
 from collections import defaultdict
 
+from poseidon.baseClasses.Logger_Base import Logger
 from poseidon.baseClasses.Monitor_Action_Base import Monitor_Action_Base
 from poseidon.baseClasses.Monitor_Helper_Base import Monitor_Helper_Base
 from poseidon.poseidonMonitor.NorthBoundControllerAbstraction.proxy.bcf.bcf import \
     BcfProxy
 
-module_logger = logging.getLogger(__name__)
+module_logger = Logger(__name__)
 
 
 class NorthBoundControllerAbstraction(Monitor_Action_Base):
@@ -35,7 +35,7 @@ class NorthBoundControllerAbstraction(Monitor_Action_Base):
 
     def __init__(self):
         super(NorthBoundControllerAbstraction, self).__init__()
-        self.logger = module_logger
+        self.logger = module_logger.logger
         self.mod_name = self.__class__.__name__
         self.config_section_name = self.mod_name
 
@@ -45,7 +45,7 @@ class Update_Switch_State(Monitor_Helper_Base):
 
     def __init__(self):
         super(Update_Switch_State, self).__init__()
-        self.logger = module_logger
+        self.logger = module_logger.logger
         self.mod_name = self.__class__.__name__
         self.retval = {}
         self.times = 0
@@ -160,14 +160,14 @@ class Update_Switch_State(Monitor_Helper_Base):
             # TODO db call to see if really need to run things
             for machine in machines:
                 h = self.make_hash(machine)
-                module_logger.critical(
+                self.logger.critical(
                     'adding address to known systems {0}'.format(machine))
                 self.make_endpoint_dict(h, 'KNOWN', machine)
         else:
             for machine in machines:
                 h = self.make_hash(machine)
                 if h not in self.endpoint_states:
-                    module_logger.critical(
+                    self.logger.critical(
                         '***** detected new address {0}'.format(machine))
                     self.make_endpoint_dict(h, 'UNKNOWN', machine)
 

--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/auth/basic/basicauth.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/auth/basic/basicauth.py
@@ -17,11 +17,10 @@
 Created on 25 July 2016
 @author: kylez
 """
-import logging
-
+from poseidon.baseClasses.Logger_Base import Logger
 from poseidon.poseidonMonitor.NorthBoundControllerAbstraction.proxy.controllerproxy import ControllerProxy
 
-module_logger = logging.getLogger(__name__)
+module_logger = Logger.logger
 
 
 class BasicAuthControllerProxy(ControllerProxy):

--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/auth/basic/test_basicauth.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/auth/basic/test_basicauth.py
@@ -19,16 +19,16 @@ Test module for basicauth.
 @author: kylez
 """
 import base64
-import logging
 import os
 
 from httmock import HTTMock
 from httmock import response
 from httmock import urlmatch
 
+from poseidon.baseClasses.Logger_Base import Logger
 from poseidon.poseidonMonitor.NorthBoundControllerAbstraction.proxy.auth.basic.basicauth import BasicAuthControllerProxy
 
-module_logger = logging.getLogger(__name__)
+module_logger = Logger.logger
 
 cur_dir = os.path.dirname(os.path.realpath(__file__))
 username = 'user'

--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/auth/cookie/cookieauth.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/auth/cookie/cookieauth.py
@@ -17,13 +17,13 @@
 Created on 25 July 2016
 @author: kylez
 """
-import logging
 from urlparse import urljoin
 
+from poseidon.baseClasses.Logger_Base import Logger
 from poseidon.poseidonMonitor.NorthBoundControllerAbstraction.proxy.controllerproxy import ControllerProxy
 
 
-module_logger = logging.getLogger(__name__)
+module_logger = Logger.logger
 
 
 class CookieAuthControllerProxy(ControllerProxy):

--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/auth/cookie/test_cookieauth.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/auth/cookie/test_cookieauth.py
@@ -19,16 +19,16 @@ Test module for cookieauth.
 @author: kylez
 """
 import json
-import logging
 import os
 
 from httmock import HTTMock
 from httmock import response
 from httmock import urlmatch
 
+from poseidon.baseClasses.Logger_Base import Logger
 from poseidon.poseidonMonitor.NorthBoundControllerAbstraction.proxy.auth.cookie.cookieauth import CookieAuthControllerProxy
 
-module_logger = logging.getLogger(__name__)
+module_logger = Logger.logger
 
 cur_dir = os.path.dirname(os.path.realpath(__file__))
 username = 'user'

--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/bcf/bcf.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/bcf/bcf.py
@@ -18,16 +18,13 @@ Created on 25 July 2016
 @author: kylez,dgrossman
 '''
 import json
-#import logging
 from urlparse import urljoin
 
 from poseidon.baseClasses.Logger_Base import Logger
 from poseidon.poseidonMonitor.NorthBoundControllerAbstraction.proxy.auth.cookie.cookieauth import CookieAuthControllerProxy
 from poseidon.poseidonMonitor.NorthBoundControllerAbstraction.proxy.mixins.jsonmixin import JsonMixin
 
-#logging.basicConfig(level=logging.DEBUG)
-#module_logger = logging.getLogger(__name__)
-module_logger = Logger(__name__)
+module_logger = Logger
 module_logger.set_level('DEBUG')
 module_logger = module_logger.logger
 

--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/bcf/bcf.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/bcf/bcf.py
@@ -25,7 +25,6 @@ from poseidon.poseidonMonitor.NorthBoundControllerAbstraction.proxy.auth.cookie.
 from poseidon.poseidonMonitor.NorthBoundControllerAbstraction.proxy.mixins.jsonmixin import JsonMixin
 
 module_logger = Logger
-module_logger.set_level('DEBUG')
 module_logger = module_logger.logger
 
 

--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/bcf/bcf.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/bcf/bcf.py
@@ -18,14 +18,18 @@ Created on 25 July 2016
 @author: kylez,dgrossman
 '''
 import json
-import logging
+#import logging
 from urlparse import urljoin
 
+from poseidon.baseClasses.Logger_Base import Logger
 from poseidon.poseidonMonitor.NorthBoundControllerAbstraction.proxy.auth.cookie.cookieauth import CookieAuthControllerProxy
 from poseidon.poseidonMonitor.NorthBoundControllerAbstraction.proxy.mixins.jsonmixin import JsonMixin
 
-logging.basicConfig(level=logging.DEBUG)
-module_logger = logging.getLogger(__name__)
+#logging.basicConfig(level=logging.DEBUG)
+#module_logger = logging.getLogger(__name__)
+module_logger = Logger(__name__)
+module_logger.set_level('DEBUG')
+module_logger = module_logger.logger
 
 
 class BcfProxy(JsonMixin, CookieAuthControllerProxy):

--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/bcf/test_bcf.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/bcf/test_bcf.py
@@ -19,17 +19,19 @@ Test module for bcf.
 @author: kylez
 """
 import json
-import logging
+#import logging
 import os
 
 from httmock import HTTMock
 from httmock import response
 from httmock import urlmatch
 
+from poseidon.baseClasses.Logger_Base import Logger
 from poseidon.poseidonMonitor.NorthBoundControllerAbstraction.proxy.bcf.bcf import BcfProxy
 from poseidon.poseidonMonitor.NorthBoundControllerAbstraction.proxy.bcf.sample_state import span_fabric_state
 
-module_logger = logging.getLogger(__name__)
+#module_logger = logging.getLogger(__name__)
+module_logger = Logger(__name__).logger
 
 cur_dir = os.path.dirname(os.path.realpath(__file__))
 username = 'user'

--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/bcf/test_bcf.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/bcf/test_bcf.py
@@ -19,7 +19,6 @@ Test module for bcf.
 @author: kylez
 """
 import json
-#import logging
 import os
 
 from httmock import HTTMock
@@ -30,8 +29,8 @@ from poseidon.baseClasses.Logger_Base import Logger
 from poseidon.poseidonMonitor.NorthBoundControllerAbstraction.proxy.bcf.bcf import BcfProxy
 from poseidon.poseidonMonitor.NorthBoundControllerAbstraction.proxy.bcf.sample_state import span_fabric_state
 
-#module_logger = logging.getLogger(__name__)
-module_logger = Logger(__name__).logger
+module_logger = Logger
+module_logger = module_logger.logger
 
 cur_dir = os.path.dirname(os.path.realpath(__file__))
 username = 'user'

--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/controllerproxy.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/controllerproxy.py
@@ -18,20 +18,19 @@ Created on 25 July 2016
 
 @author: kylez
 """
-import logging
 import requests
 from urlparse import urljoin
 
 from poseidon.baseClasses.Logger_Base import Logger
 
-#module_logger = logging.getLogger(__name__)
-module_logger = Logger(__name__)
+module_logger = Logger
+module_logger = module_logger.logger
 
 
 class ControllerProxy(object):
 
     def __init__(self, base_uri, *args, **kwargs):
-        self.logger = module_logger.logger
+        self.logger = module_logger
         self.base_uri = base_uri
         self.session = requests.Session()
 

--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/controllerproxy.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/controllerproxy.py
@@ -19,17 +19,19 @@ Created on 25 July 2016
 @author: kylez
 """
 import logging
+import requests
 from urlparse import urljoin
 
-import requests
+from poseidon.baseClasses.Logger_Base import Logger
 
-module_logger = logging.getLogger(__name__)
+#module_logger = logging.getLogger(__name__)
+module_logger = Logger(__name__)
 
 
 class ControllerProxy(object):
 
     def __init__(self, base_uri, *args, **kwargs):
-        self.logger = module_logger
+        self.logger = module_logger.logger
         self.base_uri = base_uri
         self.session = requests.Session()
 

--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/mixins/jsonmixin.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/mixins/jsonmixin.py
@@ -20,8 +20,8 @@ Created on 25 July 2016
 import json
 import logging
 
-module_logger = logging.getLogger(__name__)
-
+from poseidon.baseClasses.Logger_Base import Logger
+module_logger = Logger.logger
 
 class JsonMixin:
 

--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/mixins/test_jsonmixin.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/mixins/test_jsonmixin.py
@@ -19,17 +19,16 @@ Test module for jsonmixin.
 @author: kylez
 """
 import json
-import logging
 import os
 
 from httmock import response
 
+from poseidon.baseClasses.Logger_Base import Logger
 from poseidon.poseidonMonitor.NorthBoundControllerAbstraction.proxy.mixins.jsonmixin import JsonMixin
 
 cur_dir = os.path.dirname(os.path.realpath(__file__))
 
-module_logger = logging.getLogger(__name__)
-
+moudle_logger = Logger.logger
 
 def test_JsonMixin():
     """

--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/onos/onos.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/onos/onos.py
@@ -17,12 +17,12 @@
 Created on 25 July 2016
 @author: kylez
 """
-import logging
-
+from poseidon.baseClasses.Logger_Base import Logger
 from poseidon.poseidonMonitor.NorthBoundControllerAbstraction.proxy.auth.basic.basicauth import BasicAuthControllerProxy
 from poseidon.poseidonMonitor.NorthBoundControllerAbstraction.proxy.mixins.jsonmixin import JsonMixin
 
-module_logger = logging.getLogger(__name__)
+module_logger = Logger
+module_logger = module_logger.logger
 
 
 class OnosProxy(JsonMixin, BasicAuthControllerProxy):

--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/onos/test_onos.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/onos/test_onos.py
@@ -19,17 +19,18 @@ Test module for onos.
 @author: kylez
 """
 import json
-import logging
 import os
 
 from httmock import HTTMock
 from httmock import response
 from httmock import urlmatch
 
+from poseidon.baseClasses.Logger_Base import Logger
 from poseidon.poseidonMonitor.NorthBoundControllerAbstraction.proxy.onos.onos import OnosProxy
 
 
-module_logger = logging.getLogger(__name__)
+module_logger = Logger
+module_logger = module_logger.logger
 cur_dir = os.path.dirname(os.path.realpath(__file__))
 username = 'user'
 password = 'pass'

--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/test_controllerProxy.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/test_controllerProxy.py
@@ -18,13 +18,12 @@ Test module for controllerproxy.
 
 @author: kylez
 """
-import logging
+#import logging
 
-
+from poseidon.baseClasses.Logger_Base import Logger
 from poseidon.poseidonMonitor.NorthBoundControllerAbstraction.proxy.controllerproxy import ControllerProxy
 
-module_logger = logging.getLogger(__name__)
-
+module_logger = Logger.logger
 
 def test_ControllerProxy():
     """

--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/test_NorthBoundControllerAbstraction.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/test_NorthBoundControllerAbstraction.py
@@ -19,10 +19,9 @@ Test module for NorthBoundControllerAbstraction.py
 Created on 28 June 2016
 @author: dgrossman
 """
-import logging
-
 import pytest
 
+from poseidon.baseClasses.Logger_Base import Logger
 from poseidon.poseidonMonitor.NorthBoundControllerAbstraction.NorthBoundControllerAbstraction import controller_interface
 
-module_logger = logging.getLogger(__name__)
+module_logger = Logger.logger

--- a/poseidon/poseidonMonitor/poseidonMonitor.py
+++ b/poseidon/poseidonMonitor/poseidonMonitor.py
@@ -111,7 +111,6 @@ class Monitor(object):
         self.logger = module_logger.logger
         self.mod_configuration = dict()
         module_logger.logger_config(None)
-        module_logger.set_level('DEBUG')
 
         self.mod_name = self.__class__.__name__
         self.skip_rabbit = skip_rabbit
@@ -129,6 +128,11 @@ class Monitor(object):
         self.Config.set_owner(self)
         self.NorthBoundControllerAbstraction = controller_interface
         self.NorthBoundControllerAbstraction.set_owner(self)
+
+        self.configSelf()
+
+        # set the logger level
+        module_logger.set_level(self.mod_configuration['logger_level'])
 
         # wire up handlers for Config
         self.logger.debug('handler Config')
@@ -153,7 +157,6 @@ class Monitor(object):
             'Update_Switch_State')
 
         self.logger.debug('----------------------')
-        self.configSelf()
         self.init_logging()
 
         scan_frequency = int(self.mod_configuration['scan_frequency'])

--- a/poseidon/poseidonMonitor/poseidonMonitor.py
+++ b/poseidon/poseidonMonitor/poseidonMonitor.py
@@ -41,7 +41,7 @@ from poseidon.poseidonMonitor.NorthBoundControllerAbstraction.NorthBoundControll
 ENDPOINT_STATES = [('K', 'KNOWN'), ('U', 'UNKNOWN'), ('M', 'MIRRORING'),
                    ('S', 'SHUTDOWN'), ('R', 'REINVESTIGATING')]
 
-module_logger = Logger(__name__)
+module_logger = Logger
 
 CTRL_C = False
 
@@ -112,7 +112,6 @@ class Monitor(object):
         self.mod_configuration = dict()
         module_logger.logger_config(None)
         module_logger.set_level('DEBUG')
-        self.count = 1
 
         self.mod_name = self.__class__.__name__
         self.skip_rabbit = skip_rabbit

--- a/poseidon/poseidonMonitor/poseidonMonitor.py
+++ b/poseidon/poseidonMonitor/poseidonMonitor.py
@@ -21,7 +21,6 @@ Created on 17 May 2016
 """
 import json
 import Queue
-import pprint
 import signal
 import sys
 import threading
@@ -222,7 +221,7 @@ class Monitor(object):
             k, v = item
             self.mod_configuration[k] = v
         ostr = '{0}:config:{1}'.format(self.mod_name, self.mod_configuration)
-        self.logger.debug(pprint.pprint(ostr, width=-1))
+        self.logger.debug(ostr)
 
     def update_state(self, endpoint_states):
         ret_val = []

--- a/poseidon/poseidonMonitor/poseidonMonitor.py
+++ b/poseidon/poseidonMonitor/poseidonMonitor.py
@@ -300,8 +300,6 @@ class Monitor(object):
         for job in self.schedule.jobs:
             self.logger.debug('CTRLC:{0}'.format(job))
             self.schedule.cancel_job(job)
-            #d = docker.from_env()
-
 
 
 def main(skip_rabbit=False):

--- a/poseidon/poseidonMonitor/requirements.txt
+++ b/poseidon/poseidonMonitor/requirements.txt
@@ -1,0 +1,9 @@
+enum==0.4.6
+httmock==1.2.6
+mock==2.0.0
+pika==0.11.0
+pylint==1.7.2
+pytest-cov==2.5.1
+pytest==3.2.1
+requests==2.18.4
+schedule==0.4.3

--- a/poseidon/poseidonMonitor/requirements.txt
+++ b/poseidon/poseidonMonitor/requirements.txt
@@ -1,9 +1,0 @@
-enum==0.4.6
-httmock==1.2.6
-mock==2.0.0
-pika==0.11.0
-pylint==1.7.2
-pytest-cov==2.5.1
-pytest==3.2.1
-requests==2.18.4
-schedule==0.4.3


### PR DESCRIPTION
There is now a logger base class that all other classes import.
Logs to both stderr and a syslog (if specified):
- `poseidon.config` has a new entry called `logger_level` to set the global level. The level is `DEBUG` by default
- To add a new syslog address, change the environment variables `SYS_LOG_HOST` and `SYS_LOG_PORT`