### PR TITLE
start_vent_collector includes metadata of desired dev_hash

### DIFF
--- a/poseidon/poseidonMonitor/poseidonMonitor.py
+++ b/poseidon/poseidonMonitor/poseidonMonitor.py
@@ -257,6 +257,12 @@ class Monitor(object):
         to be taken, starts vent collector for that device with the
         options specified in poseidon.config.
         '''
+        endpoint_states = self.uss.return_endpoint_state()
+        try:
+            metadata = endpoint_states.get(dev_hash, {})
+        except AttributeError:
+            # If return_endpoint_state() returns NoneType
+            metadata = {}
         try:
             payload = {
                 'nic': self.mod_configuration['collector_nic'],
@@ -264,7 +270,8 @@ class Monitor(object):
                 'interval': self.mod_configuration['collector_interval'],
                 'filter': '\'host {0}\''.format(
                     self.uss.get_endpoint_ip(dev_hash)),
-                'iters': str(num_captures)}
+                'iters': str(num_captures),
+                'metadata': metadata}
             self.logger.debug('vent payload: ' + str(payload))
             vent_addr = self.mod_configuration[
                 'vent_ip'] + ':' + self.mod_configuration['vent_port']

--- a/poseidon/poseidonMonitor/test_poseidonMonitor.py
+++ b/poseidon/poseidonMonitor/test_poseidonMonitor.py
@@ -50,11 +50,19 @@ def test_start_vent_collector():
         def __init__(self):
             pass
 
+    class MockUSS:
+        @staticmethod
+        def return_endpoint_state():
+            # Really don't care endpoint state here
+            return {}
+
     mock_monitor = MockMonitor()
     mock_monitor.logger = module_logger
     dev_hash = 'test'
     num_cuptures = 3
+    mock_monitor.uss = MockUSS()
     mock_monitor.start_vent_collector(dev_hash, num_cuptures)
+
 
 def test_get_q_item():
     class MockMQueue:

--- a/poseidon/poseidonMonitor/test_poseidonMonitor.py
+++ b/poseidon/poseidonMonitor/test_poseidonMonitor.py
@@ -39,28 +39,28 @@ def test_start_vent_collector():
     poseidonMonitor.CTRL_C = False
     poseidonMonitor.requests = requests()
 
-    class MockMonitor(Monitor):
-        mod_configuration = {
-            'collector_nic': 2,
-            'vent_ip': '0.0.0.0',
-            'vent_port': '8080',
-        }
-
-        # no need to init the monitor
-        def __init__(self):
-            pass
-
     class MockUSS:
         @staticmethod
         def return_endpoint_state():
             # Really don't care endpoint state here
             return {}
 
+    class MockMonitor(Monitor):
+        mod_configuration = {
+            'collector_nic': 2,
+            'vent_ip': '0.0.0.0',
+            'vent_port': '8080',
+        }
+        uss = MockUSS()
+
+        # no need to init the monitor
+        def __init__(self):
+            pass
+
     mock_monitor = MockMonitor()
     mock_monitor.logger = module_logger
     dev_hash = 'test'
     num_cuptures = 3
-    mock_monitor.uss = MockUSS()
     mock_monitor.start_vent_collector(dev_hash, num_cuptures)
 
 


### PR DESCRIPTION
This PR resolves #258 

Basically, the payload posted with `start_vent_collector` now includes metadata for the addressed `dev_hash`.