### PR TITLE
Support Python 3 package names.

### DIFF
--- a/poseidon/baseClasses/Rabbit_Base.py
+++ b/poseidon/baseClasses/Rabbit_Base.py
@@ -22,7 +22,7 @@ import time
 import types
 from functools import partial
 
-from Logger_Base import Logger
+from .Logger_Base import Logger
 
 
 module_logger = Logger

--- a/poseidon/poseidonMonitor/Config/Config.py
+++ b/poseidon/poseidonMonitor/Config/Config.py
@@ -21,7 +21,10 @@ file.
 Created on 17 May 2016
 @author: dgrossman, lanhamt
 """
-import ConfigParser
+try:
+    import ConfigParser
+except ImportError:
+    import configparser as ConfigParser
 import json
 import os
 

--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/NorthBoundControllerAbstraction.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/NorthBoundControllerAbstraction.py
@@ -18,7 +18,10 @@ Created on 17 May 2016
 '''
 import hashlib
 import json
-import Queue
+try:
+    import Queue
+except ImportError:
+    import queue as Queue
 from collections import defaultdict
 
 from poseidon.baseClasses.Logger_Base import Logger

--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/auth/cookie/cookieauth.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/auth/cookie/cookieauth.py
@@ -17,8 +17,10 @@
 Created on 25 July 2016
 @author: kylez
 """
-from urlparse import urljoin
-
+try:
+    from urlparse import urljoin
+except ImportError:
+    from urllib.parse import urljoin
 from poseidon.baseClasses.Logger_Base import Logger
 from poseidon.poseidonMonitor.NorthBoundControllerAbstraction.proxy.controllerproxy import ControllerProxy
 

--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/controllerproxy.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/proxy/controllerproxy.py
@@ -19,8 +19,10 @@ Created on 25 July 2016
 @author: kylez
 """
 import requests
-from urlparse import urljoin
-
+try:
+    from urlparse import urljoin
+except ImportError:
+    from urllib.parse import urljoin
 from poseidon.baseClasses.Logger_Base import Logger
 
 module_logger = Logger

--- a/poseidon/poseidonMonitor/poseidonMonitor.py
+++ b/poseidon/poseidonMonitor/poseidonMonitor.py
@@ -20,7 +20,10 @@ Created on 17 May 2016
 @author: Charlie Lewis, dgrossman
 """
 import json
-import Queue
+try:
+    import Queue
+except ImportError:
+    import queue as Queue
 import signal
 import sys
 import threading


### PR DESCRIPTION
Python 3 uses different package names for some things. This code lets you support both Python 2 and 3 package names with the same code. 