### PR TITLE
Hacktober tmp path fix

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,4 +8,5 @@ Brad Hatch <bradh@lab41.org>
 David Grossman <dgrossman@iqt.org>
 Abhi Ganesh <aganesh@iqt.org>
 Travis Lanham <tlanham@iqt.org>
+Daniel Popescu <danielpops@gmail.com>
 Kyle Z <kylez@lab41.org>

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ MAINTAINER dgrossman@iqt.org
 
 COPY . /poseidonWork
 WORKDIR /poseidonWork
-RUN ln -s /poseidonWork /tmp/poseidonWork 
 ENV PYTHONPATH /poseidonWork/poseidon:$PYTHONPATH
+ENV POSEIDON_CONFIG /poseidonWork/config/poseidon.config
 
 # install dependencies of poseidon modules for poseidon
 RUN find . -name requirements.txt -type f -exec pip install -r {} \;

--- a/Dockerfile.docs
+++ b/Dockerfile.docs
@@ -21,9 +21,9 @@ EXPOSE 8080:8080
 COPY . /poseidonWork
 WORKDIR /poseidonWork
 ENV PYTHONPATH /poseidonWork/poseidon:$PYTHONPATH
+ENV POSEIDON_CONFIG /poseidonWork/config/poseidon.config
 
 # install dependencies of poseidon modules for poseidon
-RUN ln -s /poseidonWork /tmp/poseidonWork 
 RUN find . -name requirements.txt -type f -exec pip install -r {} \;
 RUN sphinx-apidoc -o docs poseidon -F --follow-links && cd docs && make html && make man
 

--- a/poseidon/poseidonMonitor/Config/Config.py
+++ b/poseidon/poseidonMonitor/Config/Config.py
@@ -33,9 +33,6 @@ from poseidon.baseClasses.Monitor_Helper_Base import Monitor_Helper_Base
 
 module_logger = Logger
 
-# poseidonWork created in docker containers
-config_template_path = '/tmp/poseidonWork/config/poseidon.config'
-
 
 class Config(Monitor_Action_Base):
 
@@ -54,8 +51,7 @@ class Config(Monitor_Action_Base):
             self.config_path = os.environ.get(
                 'POSEIDON_CONFIG')               # pragma: no cover
         else:
-            self.logger.info('From the Docker hardcode')
-            self.config_path = config_template_path
+            raise Exception('Could not find poseidon config. Make sure to set the POSEIDON_CONFIG environment variable')
         self.config.readfp(open(self.config_path, 'r'))
 
     def configure(self):


### PR DESCRIPTION
Fixes #296 by setting the `POSEIDON_CONFIG` environment variable in the Dockerfile(s) and failing if the variable is not being set. The support was already there to consume this variable in Config.py.

I assume one of the maintainers will need to configure the circle-ci job(s) to pass this variable if it is not already doing so. Alternatively, we could continue to defaulting to the hard-coded `/tmp/` reference in the code (e.g. revert my changes to Config.py). Let me know what you guys think