### PR TITLE
Add a makefile to make development build / run scenarios simpler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+TAG=${WHOAMI}-poseidon
+WHOAMI := $(shell who | awk '{print $$1}')
+
+build_poseidon:
+	docker build -f ./Dockerfile -t $(TAG) .
+
+run_poseidon: build_poseidon
+	docker run --rm -it $(TAG)
+
+run_sh: build_poseidon
+	docker run --rm -it --entrypoint sh $(TAG)
+
+build_docs:
+	docker build -f ./Dockerfile.docs -t $(TAG)-docs .
+
+run_docs: build_docs
+	docker run --rm -it -p 8080 $(TAG)-docs
+
+.PHONY:  build_poseidon run_poseidon run_sh build_docs run_docs


### PR DESCRIPTION
This makes it so that the instructions for building are simplified down to `make build_poseidon` or `make build_docs` and running is simplified to `make run_poseidon` or `make run_docs`. Also provided a `make run_sh` target for dropping into the container with a shell for adhoc debugging purposes.

This way people don't need to remember the specific docker invocation(s) required.