### PR TITLE
Update Makefile for docker.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,13 @@ TAG=${WHOAMI}-poseidon
 WHOAMI := $(shell who | awk '{print $$1}')
 
 build_poseidon:
-	docker build -f ./Dockerfile -t $(TAG) .
+	docker build -f ./Dockerfile.poseidon -t $(TAG) .
 
 run_poseidon: build_poseidon
 	docker run --rm -it $(TAG)
+
+run_dev:
+	docker run --rm -v "$(shell pwd):/poseidonWork" -it $(TAG)
 
 run_sh: build_poseidon
 	docker run --rm -it --entrypoint sh $(TAG)


### PR DESCRIPTION
Fix the dockerfile reference in build_poseidon.
Add a run_dev that mounts the local folder into
/poseidonWork so that local changes can be tested
without rebuilding the whole container.