### PR TITLE
Add .dockerignore to prevent rebuilds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.circleci
+.coveragerc
+.gitignore
+.git
+AUTHORS
+CHANGELOG.md
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md
+Dockerfile.docs
+Dockerfile.poseidon
+LICENSE
+MAINTAINERS.md
+Makefile
+README.md
+VERSION


### PR DESCRIPTION
This will ignore files in the repo on docker builds
preventing a change in a file like README.md from
breaking the docker build cache and causing a rebuild.