### PR TITLE
Correction in url in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,4 +97,4 @@ It is every maintainer's responsibility to:
 
 Just like everything else: by making a pull request :)
 
-*Derivative work from [Docker](https://github.com/doocker/docker/blob/master/CONTRIBUTING.md).*
+*Derivative work from [Docker](https://github.com/moby/moby/blob/master/CONTRIBUTING.md).*


### PR DESCRIPTION
There was a typo in URL :)

The docker project is now called moby.