### PR TITLE
Hotfix/makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-TAG=${WHOAMI}-poseidon
-WHOAMI := $(shell who | awk '{print $$1}')
+TAG=`whoami`-poseidon
 
 build_poseidon:
 	docker build -f ./Dockerfile.poseidon -t $(TAG) .


### PR DESCRIPTION
Fix for Issue #366 : Makefile TAG variable/awk error on macOS