### PR TITLE
Use python3 alpine as base image

### DIFF
--- a/Dockerfile.poseidon
+++ b/Dockerfile.poseidon
@@ -1,4 +1,4 @@
-FROM continuumio/anaconda3
+FROM frolvlad/alpine-python3
 MAINTAINER dgrossman@iqt.org
 
 COPY . /poseidonWork


### PR DESCRIPTION
Partially fixes #381 
Using alpine python as base image for python we can reduce the image size to 74 MB.
![image](https://user-images.githubusercontent.com/3822880/32117925-9a2bf38e-bb6d-11e7-802a-88aa93b143d4.png)

The docs image will need some research as some of latex libs used are not available in alpine repo