### PR TITLE
Quote controller_mirror_ports because it contains shell-special chara…

### DIFF
--- a/helpers/run
+++ b/helpers/run
@@ -12,7 +12,7 @@ docker run -dit \
            -e controller_log_file=$controller_log_file \
            -e controller_config_file=$controller_config_file \
            -e collector_nic=$collector_nic \
-           -e controller_mirror_ports=$controller_mirror_ports \
+           -e controller_mirror_ports="$controller_mirror_ports" \
            -e max_concurrent_reinvestigations=$max_concurrent_reinvestigations \
            --name vent \
            cyberreboot/vent


### PR DESCRIPTION
…cters.