### PR TITLE
Fixes #397

### DIFF
--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/EndpointWrapper.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/EndpointWrapper.py
@@ -152,3 +152,13 @@ class Endpoint_Wrapper():
         for my_hash in hashes:
             if self.state[my_hash].endpoint_data['active'] == 0:
                 del self.state[my_hash]
+
+    def get_endpoints_in_state(self, state):
+        e_states = self.state.copy()
+        for my_hash in e_states.keys():
+            endpoint = e_states[my_hash]
+            if endpoint.state != state:
+                del e_states[my_hash]
+
+        return e_states
+        

--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/UpdateSwitchState.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/UpdateSwitchState.py
@@ -65,8 +65,6 @@ class Update_Switch_State(Monitor_Helper_Base):
         self.reinvestigation_frequency = 900
         self.max_concurrent_reinvestigations = 2
 
-        self.mirrored_endpoint_count = 0
-
         self.sdnc = None
         self.first_time = True
         self.endpoints = Endpoint_Wrapper()
@@ -75,9 +73,6 @@ class Update_Switch_State(Monitor_Helper_Base):
     def return_endpoint_state(self):
         ''' give access to the endpoint_states '''
         return self.endpoints
-
-    def get_mirrored_endpoint_count(self):
-        return self.mirrored_endpoint_count
 
     def first_run(self):
         ''' do some pre-run setup/configuration '''
@@ -179,7 +174,6 @@ class Update_Switch_State(Monitor_Helper_Base):
             next_state = self.endpoints.get_endpoint_next(my_hash)
             self.sdnc.mirror_mac(my_mac, messages=messages)
             self.endpoints.change_endpoint_state(my_hash)
-            self.mirrored_endpoint_count += 1
             self.poseidon_logger.debug(
                 'endpoint:{0}:{1}:{2}:{3}'.format(my_hash, my_mac, my_ip, next_state))
             return True
@@ -192,7 +186,6 @@ class Update_Switch_State(Monitor_Helper_Base):
             my_ip = self.endpoints.get_endpoint_ip(my_hash)
             next_state = self.endpoints.get_endpoint_next(my_hash)
             self.sdnc.unmirror_mac(my_mac, messages=messages)
-            self.mirrored_endpoint_count -= 1
             self.poseidon_logger.debug(
                 'endpoint:{0}:{1}:{2}:{3}'.format(my_hash, my_mac, my_ip, next_state))
             return True

--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/UpdateSwitchState.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/UpdateSwitchState.py
@@ -65,6 +65,8 @@ class Update_Switch_State(Monitor_Helper_Base):
         self.reinvestigation_frequency = 900
         self.max_concurrent_reinvestigations = 2
 
+        self.mirrored_endpoint_count = 0
+
         self.sdnc = None
         self.first_time = True
         self.endpoints = Endpoint_Wrapper()
@@ -73,6 +75,9 @@ class Update_Switch_State(Monitor_Helper_Base):
     def return_endpoint_state(self):
         ''' give access to the endpoint_states '''
         return self.endpoints
+
+    def get_mirrored_endpoint_count(self):
+        return self.mirrored_endpoint_count
 
     def first_run(self):
         ''' do some pre-run setup/configuration '''
@@ -174,6 +179,7 @@ class Update_Switch_State(Monitor_Helper_Base):
             next_state = self.endpoints.get_endpoint_next(my_hash)
             self.sdnc.mirror_mac(my_mac, messages=messages)
             self.endpoints.change_endpoint_state(my_hash)
+            self.mirrored_endpoint_count += 1
             self.poseidon_logger.debug(
                 'endpoint:{0}:{1}:{2}:{3}'.format(my_hash, my_mac, my_ip, next_state))
             return True
@@ -186,6 +192,7 @@ class Update_Switch_State(Monitor_Helper_Base):
             my_ip = self.endpoints.get_endpoint_ip(my_hash)
             next_state = self.endpoints.get_endpoint_next(my_hash)
             self.sdnc.unmirror_mac(my_mac, messages=messages)
+            self.mirrored_endpoint_count -= 1
             self.poseidon_logger.debug(
                 'endpoint:{0}:{1}:{2}:{3}'.format(my_hash, my_mac, my_ip, next_state))
             return True

--- a/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/test_NorthBoundControllerAbstraction.py
+++ b/poseidon/poseidonMonitor/NorthBoundControllerAbstraction/test_NorthBoundControllerAbstraction.py
@@ -564,3 +564,20 @@ def test_print_endpoint_state():
     state = 'TEST_STATE'
     make_endpoint_dict(uss.endpoints.state, hash_value, state, endpoint_data)
     uss.endpoints.print_endpoint_state()
+
+def test_get_endpoints_in_state():
+    uss = Update_Switch_State()
+    uss.first_time = False
+    endpoint_data = dict({'ip-address': '10.0.0.99',
+                          'mac': '20:4c:9e:5f:e3:c3',
+                          'segment': 'to-core-router',
+                          'tenant': 'EXTERNAL',
+                          'active': 1,
+                          'name': None})
+    hash_value = '87a07fa79d4d855e5392e6863586584ebacc9d2a'
+    state = 'TEST_STATE'
+    make_endpoint_dict(uss.endpoints.state, hash_value, state, endpoint_data)
+    actual = len(uss.endpoints.get_endpoints_in_state('TEST_STATE'))
+    expected = 1
+
+    assert actual == expected

--- a/poseidon/poseidonMonitor/poseidonMonitor.py
+++ b/poseidon/poseidonMonitor/poseidonMonitor.py
@@ -253,7 +253,7 @@ def schedule_job_reinvestigation(max_investigations, currently_mirrored, endpoin
     # get random order of things that are known
     random.shuffle(candidates)
 
-    if currently_investigating + currently_mirrored < max_investigations:
+    if currently_investigating + currently_mirrored <= max_investigations:
         ostr = 'room to investigate'
         logger.debug(ostr)
         for x in range(max_investigations - currently_investigating):

--- a/poseidon/poseidonMonitor/poseidonMonitor.py
+++ b/poseidon/poseidonMonitor/poseidonMonitor.py
@@ -236,7 +236,7 @@ def schedule_thread_worker(schedule, logger):
     sys.exit()
 
 
-def schedule_job_reinvestigation(max_investigations, endpoints, logger):
+def schedule_job_reinvestigation(max_investigations, currently_mirrored, endpoints, logger):
     ''' put endpoints into the reinvestigation state if possible '''
     ostr = 'reinvestigation time'
     logger.debug(ostr)
@@ -253,7 +253,7 @@ def schedule_job_reinvestigation(max_investigations, endpoints, logger):
     # get random order of things that are known
     random.shuffle(candidates)
 
-    if currently_investigating < max_investigations:
+    if currently_investigating + currently_mirrored < max_investigations:
         ostr = 'room to investigate'
         logger.debug(ostr)
         for x in range(max_investigations - currently_investigating):
@@ -359,6 +359,7 @@ class Monitor(object):
         self.schedule.every(reinvestigation_frequency).seconds.do(
             partial(schedule_job_reinvestigation,
                     max_investigations=max_concurrent_reinvestigations,
+                    currently_mirrored=len(self.uss.endpoints.get_endpoints_in_state('MIRRORING')),
                     endpoints=self.NorthBoundControllerAbstraction.get_endpoint(
                         'Update_Switch_State').endpoints,
                     logger=self.poseidon_logger))

--- a/poseidon/poseidonMonitor/test_poseidonMonitor.py
+++ b/poseidon/poseidonMonitor/test_poseidonMonitor.py
@@ -1224,7 +1224,7 @@ def test_schedule_job_reinvestigation():
 
     assert len(epw.state) == 9
 
-    poseidonMonitor.schedule_job_reinvestigation(9, epw, MockLogger().logger)
+    poseidonMonitor.schedule_job_reinvestigation(9, 1, epw, MockLogger().logger)
 
     epw = Endpoint_Wrapper()
 
@@ -1329,15 +1329,15 @@ def test_schedule_job_reinvestigation():
     for s in stuff:
         epw.state[s] = stuff[s]
 
-    poseidonMonitor.schedule_job_reinvestigation(4, epw, MockLogger().logger)
+    poseidonMonitor.schedule_job_reinvestigation(4, 1, epw, MockLogger().logger)
 
     epw = Endpoint_Wrapper()
     #end_points = {}
-    poseidonMonitor.schedule_job_reinvestigation(4, epw, MockLogger().logger)
+    poseidonMonitor.schedule_job_reinvestigation(4, 0, epw, MockLogger().logger)
 
     epw.state['4ee39d254db3e4a5264b75ce8ae312d69f9e73a3'] = stuff['4ee39d254db3e4a5264b75ce8ae312d69f9e73a3']
     #end_points = {"hash_0": {"MALFORMED": "YES"}}
-    poseidonMonitor.schedule_job_reinvestigation(4, epw, MockLogger().logger)
+    poseidonMonitor.schedule_job_reinvestigation(4, 0, epw, MockLogger().logger)
 
 
 def test_update_next_state():


### PR DESCRIPTION
- added method get_endpoints_in_state to endpoint wrapper
- check that number of mirroring endpoints + number of current investigations
  is less than max_investigations when scheduling a reinvestigation