### PR TITLE
Version Badge + URL Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![codecov](https://codecov.io/gh/CyberReboot/poseidon/branch/master/graph/badge.svg?token=ORXmFYC3MM)](https://codecov.io/gh/CyberReboot/poseidon)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/e31df16fa65447bf8527e366c6271bf3)](https://www.codacy.com/app/CyberReboot/poseidon?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=CyberReboot/poseidon&amp;utm_campaign=Badge_Grade)
 [![Docker Hub Downloads](https://img.shields.io/docker/pulls/cyberreboot/poseidon.svg)](https://hub.docker.com/r/cyberreboot/poseidon/)
+[![Latest Version @ Cloudsmith](https://api-prd.cloudsmith.io/badges/version/cyberreboot/poseidon/deb/poseidon/latest/d=ubuntu%252Fartful/?render=true)](https://cloudsmith.io/~cyberreboot/repos/poseidon/packages/)
 
 > Software Defined Network Situational Awareness
 
@@ -47,7 +48,7 @@ The Poseidon project originally began as an experiment to test the merits of lev
 
 ## Installing
 
-On Ubuntu, this will download and install our `.deb` package from [Cloudsmith](https://cloudsmith.io/package/ns/cyberreboot/repos/poseidon/packages/).
+On Ubuntu, this will download and install our `.deb` package from [Cloudsmith](https://cloudsmith.io/~/cyberreboot/repos/poseidon/packages/).
 ```
 sudo usermod -aG docker $USER
 sudo apt-get install -y apt-transport-https curl


### PR DESCRIPTION
Added a version badge for Cloudsmith (via the latest 0.33 release), and fixed link (URLs were shortened).

Entirely optional of course, but I thought I'd lend to hand to minimise the annoyance of URLs changing. :-)