### PR TITLE
Add poseidon.namespace labels to dockerfiles for unique identification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM alpine:3.9
 LABEL maintainer="Charlie Lewis <clewis@iqt.org>"
+LABEL poseidon.namespace="primary"
 
 COPY requirements.txt requirements.txt
 COPY healthcheck /healthcheck

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,6 @@
 FROM alpine:3.9
 LABEL maintainer="Charlie Lewis <clewis@iqt.org>"
+LABEL poseidon.namespace="api"
 
 COPY requirements.txt requirements.txt
 COPY healthcheck /healthcheck

--- a/bin/poseidon
+++ b/bin/poseidon
@@ -118,8 +118,8 @@ function check_args()
                 exit
                 ;;
             -e|shell)
-                if [ "$(docker ps -q --filter "label=vent.namespace=cyberreboot/poseidon" --filter "label=vent.name=" | wc -l)" -eq 1 ]; then
-                    docker exec -it "$(docker ps -q --filter "label=vent.namespace=cyberreboot/poseidon" --filter "label=vent.name=")" python3 /poseidon/poseidon/cli/cli.py "${@:2}"
+                if [ "$(docker ps -q --filter "label=poseidon.namespace=primary" --filter "label=vent.name=" | wc -l)" -eq 1 ]; then
+                    docker exec -it "$(docker ps -q --filter "label=poseidon.namespace=primary" --filter "label=vent.name=")" python3 /poseidon/poseidon/cli/cli.py "${@:2}"
                 else
                     echo "Poseidon isn't running, you must first start Poseidon to use the shell."
                 fi


### PR DESCRIPTION
Have the shell prereqs look for poseidon.namespace=primary to identify
the poseidon container to allow the shell to be run from a fork/branch