### PR TITLE
namespacish of coprocessor states

### DIFF
--- a/poseidon/helpers/endpoint.py
+++ b/poseidon/helpers/endpoint.py
@@ -114,27 +114,27 @@ class Endpoint:
             'dest': 'inactive', 'before': 'update_state_history'}
     ]
 
-    copro_states = ['unknown', 'coprocessing', 'nominal', 'suspicious', 'queued']
+    copro_states = ['copro_unknown', 'copro_coprocessing', 'copro_nominal', 'copro_suspicious', 'copro_queued']
 
     copro_transitions = [
-        {'trigger': 'coprocess', 'source': 'unknown',
-            'dest': 'coprocessing', 'before': 'update_copro_history'},
-        {'trigger': 'queue', 'source': 'unknown',
-            'dest': 'queued', 'before': 'update_copro_history'},  
-        {'trigger': 'coprocess', 'source': 'queued',
-            'dest': 'coprocessing', 'before': 'update_copro_history'},
-        {'trigger': 'nominal', 'source': 'coprocessing',
-            'dest': 'nominal', 'before': 'update_copro_history'},
-        {'trigger': 'suspicious', 'source': 'coprocessing',
-            'dest': 'suspicious', 'before': 'update_copro_history'},
-        {'trigger': 'queue', 'source': 'nominal',
-            'dest': 'queued', 'before': 'update_copro_history'},  
-        {'trigger': 'coprocess', 'source': 'nominal',
-            'dest': 'coprocessing', 'before': 'update_copro_history'},
-        {'trigger': 'queue', 'source': 'suspicious',
-            'dest': 'queued', 'before': 'update_copro_history'},  
-        {'trigger': 'coprocess', 'source': 'suspicious',
-            'dest': 'coprocessing', 'before': 'update_copro_history'},
+        {'trigger': 'copro_coprocess', 'source': 'copro_unknown',
+            'dest': 'copro_coprocessing', 'before': 'update_copro_history'},
+        {'trigger': 'copro_queue', 'source': 'copro_unknown',
+            'dest': 'copro_queued', 'before': 'update_copro_history'},  
+        {'trigger': 'copro_coprocess', 'source': 'copro_queued',
+            'dest': 'copro_coprocessing', 'before': 'update_copro_history'},
+        {'trigger': 'copro_nominal', 'source': 'copro_coprocessing',
+            'dest': 'copro_nominal', 'before': 'update_copro_history'},
+        {'trigger': 'copro_suspicious', 'source': 'copro_coprocessing',
+            'dest': 'copro_suspicious', 'before': 'update_copro_history'},
+        {'trigger': 'copro_queue', 'source': 'copro_nominal',
+            'dest': 'copro_queued', 'before': 'update_copro_history'},  
+        {'trigger': 'copro_coprocess', 'source': 'copro_nominal',
+            'dest': 'copro_coprocessing', 'before': 'update_copro_history'},
+        {'trigger': 'copro_queue', 'source': 'copro_suspicious',
+            'dest': 'copro_queued', 'before': 'update_copro_history'},  
+        {'trigger': 'copro_coprocess', 'source': 'copro_suspicious',
+            'dest': 'copro_coprocessing', 'before': 'update_copro_history'},
 
     ]
 

--- a/poseidon/main.py
+++ b/poseidon/main.py
@@ -127,7 +127,7 @@ def schedule_job_coprocessing(schedule_func):
                 chosen = candidates.pop()
                 schedule_func.logger.info('Starting coprocessing on: {0} {1}'.format(
                     chosen.name, chosen.state))
-                chosen.coprocess()
+                chosen.copro_coprocess()
                 chosen.p_prev_states.append(
                     (chosen.state, int(time.time())))
                 schedule_func.s.coprocess_endpoint(chosen)
@@ -939,7 +939,7 @@ class Monitor:
             if not endpoint.copro_ignore and endpoint.copro_state == 'queued']
         self.s.coprocessing = len([
             endpoint for endpoint in self.s.endpoints.values()
-            if endpoint.copro_state in ['coprocessing']])
+            if endpoint.copro_state in ['copro_coprocessing']])
         # mirror things in the order they got added to the queue
         queued_endpoints = sorted(
              queued_endpoints, key=lambda x: x.p_prev_copro_states[-1][1])
@@ -962,11 +962,11 @@ class Monitor:
             if not endpoint.copro_ignore:
                 if self.s.sdnc:
                     if endpoint.copro_state == 'unknown':
-                        endpoint.p_next_copro_state = 'coprocessing'
-                        endpoint.queue()
+                        endpoint.p_next_copro_state = 'copro_coprocessing'
+                        endpoint.copro_queue()
                         endpoint.p_prev_copro_states.append(
                             (endpoint.copro_state, int(time.time())))
-                    elif endpoint.copro_state in ['coprocessing']:
+                    elif endpoint.copro_state in ['copro_coprocessing']:
                         cur_time = int(time.time())
                         # timeout after 2 times the reinvestigation frequency
                         # in case something didn't report back, put back in an
@@ -974,13 +974,13 @@ class Monitor:
                         if cur_time - endpoint.p_prev_copro_states[-1][1] > 2*self.controller['coprocessing_frequency']:
                             self.logger.debug(
                                 'timing out: {0} and setting to unknown'.format(endpoint.name))
-                            self.s.unmirror_endpoint(endpoint)
-                            endpoint.unknown()
+                            self.s.uncoprocess_endpoint(endpoint)
+                            endpoint.copro_unknown()
                             endpoint.p_prev_copro_states.append(
                                 (endpoint.copro_state, int(time.time())))
                 else:
                     if endpoint.state != 'nominal':
-                        endpoint.nominal()
+                        endpoint.copro_nominal()
 
 
     def process(self):


### PR DESCRIPTION
prefixing coprocessor state machine names in order to avoid collisions with the state names used for mirroring.