### PR TITLE
Ignore learns/events on stack ports (so we learn only on edge ports),…

### DIFF
--- a/config/poseidon.config
+++ b/config/poseidon.config
@@ -22,11 +22,15 @@ rabbit_port = 5672
 [Faucet]
 controller_log_file = /var/log/faucet/faucet.log
 controller_config_file = /etc/faucet/faucet.yaml
-controller_mirror_ports = '{"switch1":3}'
+# Dict of one port per switch to use for mirroring ports on that switch (e.g. '{"switch1": 3})
+controller_mirror_ports = '{"switch1": 3}'
 tunnel_vlan = 999
 tunnel_name = poseidon_tunnel
+# List of integer VIDs to ignore (e.g. '[123,456]')
 ignore_vlans = '[]'
+# Dict of one port per switch to ignore (e.g. '{"switch1": 99}')
 ignore_ports = '{}'
+# Dict of one trunk port per switch to ignore (e.g. '{"switch1": 99}')
 trunk_ports = '{}'
 FA_RABBIT_ENABLED = True
 FA_RABBIT_HOST = RABBIT_SERVER

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -4,7 +4,8 @@ Test module for faucet parser.
 @author: Charlie Lewis
 """
 import os
-
+import shutil
+import tempfile
 from poseidon.controllers.faucet.faucet import FaucetProxy
 from poseidon.controllers.faucet.helpers import get_config_file
 from poseidon.controllers.faucet.helpers import parse_rules
@@ -12,6 +13,8 @@ from poseidon.controllers.faucet.helpers import represent_none
 from poseidon.controllers.faucet.parser import Parser
 from poseidon.helpers.config import Config
 from poseidon.helpers.endpoint import endpoint_factory
+
+SAMPLE_CONFIG = 'tests/sample_faucet_config.yaml'
 
 
 def test_ignore_events():
@@ -25,19 +28,23 @@ def test_ignore_events():
             {'dp_name': 'switch99', message_type: {'vid': 333, 'port_no': 11}})
         assert not parser.ignore_event(
             {'dp_name': 'switch99', message_type: {'vid': 333, 'port_no': 99}})
+        assert parser.ignore_event(
+            {'dp_name': 'switch99', message_type: {'vid': 333, 'port_no': 99, 'stack_descr': 'something'}})
     assert parser.ignore_event(
         {'dp_name': 'switch123', 'UNKNOWN': {'vid': 123, 'port_no': 123}})
 
 
 
 def test_parse_rules():
-    parse_rules(os.path.join(os.getcwd(),
-                             'tests/sample_faucet_config.yaml'))
+    with tempfile.TemporaryDirectory() as tmpdir:
+        shutil.copy(SAMPLE_CONFIG, tmpdir)
+        parse_rules(os.path.join(tmpdir, os.path.basename(SAMPLE_CONFIG)))
 
 
 def test_clear_mirrors():
-    Parser.clear_mirrors(os.path.join(os.getcwd(),
-                                      'tests/sample_faucet_config.yaml'))
+    with tempfile.TemporaryDirectory() as tmpdir:
+        shutil.copy(SAMPLE_CONFIG, tmpdir)
+        Parser.clear_mirrors(os.path.join(tmpdir, os.path.basename(SAMPLE_CONFIG)))
 
 
 def test_represent_none():
@@ -94,9 +101,8 @@ def test_Parser():
     check_config(parser, os.path.join(config_dir, 'faucet.yaml'), endpoints)
     check_config(parser2, os.path.join(config_dir, 'faucet.yaml'), endpoints)
     check_config(proxy, os.path.join(config_dir, 'faucet.yaml'), endpoints)
-    check_config(parser, os.path.join(os.getcwd(),
-                                      'tests/sample_faucet_config.yaml'), endpoints)
-    check_config(parser2, os.path.join(os.getcwd(),
-                                       'tests/sample_faucet_config.yaml'), endpoints)
-    check_config(proxy, os.path.join(os.getcwd(),
-                                     'tests/sample_faucet_config.yaml'), endpoints)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        shutil.copy(SAMPLE_CONFIG, tmpdir)
+        check_config(parser, os.path.join(tmpdir, os.path.basename(SAMPLE_CONFIG)), endpoints)
+        check_config(parser2, os.path.join(tmpdir, os.path.basename(SAMPLE_CONFIG)), endpoints)
+        check_config(proxy, os.path.join(tmpdir, os.path.basename(SAMPLE_CONFIG)), endpoints)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4,11 +4,12 @@ Created on 31 Dec 2019
 @author: cglewis
 """
 import os
-
 from workers.worker import callback
 from workers.worker import load_workers
 from workers.worker import setup_docker
 from workers.worker import setup_redis
+
+WORKERS_JSON = 'workers/workers.json'
 
 
 def test_setup_docker():
@@ -17,8 +18,7 @@ def test_setup_docker():
 
 
 def test_load_workers():
-    os.system('cp workers/workers.json workers.json')
-    workers = load_workers()
+    workers = load_workers(WORKERS_JSON)
 
 
 def test_setup_redis():
@@ -39,24 +39,24 @@ def test_callback():
     method = MockMethod()
     body = '{"id": "", "type": "metadata", "file_path": "/files/tcprewrite-dot1q-2019-12-31-17_33_32.961111-UTC/pcap-node-splitter-2019-12-31-17_34_17.314910-UTC/clients/trace_5c7820e51dbabbf0476097dda838c7eabfa8e160_2019-12-31_17_18_17-client-ip-38-103-36-98-192-168-0-46-38-103-36-98-eth-udpencap-ip-frame-wsshort-udp-esp-port-4500.pcap", "data": "", "results": {"tool": "p0f", "version": "0.1.7"}}'
     body = body.encode('utf-8')
-    callback(ch, method, None, body)
+    callback(ch, method, None, body, workers_json=WORKERS_JSON)
 
     body = '{"id": "", "type": "metadata", "file_path": "/files/tcprewrite-dot1q-2019-12-31-17_33_32.961111-UTC/pcap-node-splitter-2019-12-31-17_34_17.314910-UTC/clients/trace_5c7820e51dbabbf0476097dda838c7eabfa8e160_2019-12-31_17_18_17-client-ip-38-103-36-98-192-168-0-46-38-103-36-98-eth-udpencap-ip-frame-wsshort-udp-esp-port-4500.pcap", "data": "foo", "results": {"tool": "p0f", "version": "0.1.7"}}'
     body = body.encode('utf-8')
-    callback(ch, method, None, body)
+    callback(ch, method, None, body, workers_json=WORKERS_JSON)
 
     body = '{"id": "", "type": "metadata", "file_path": "/files/tcprewrite-dot1q-2019-12-31-17_33_32.961111-UTC/pcap-node-splitter-2019-12-31-17_34_17.314910-UTC/clients/trace_5c7820e51dbabbf0476097dda838c7eabfa8e160_2019-12-31_17_18_17-client-ip-38-103-36-98-192-168-0-46-38-103-36-98-eth-udpencap-ip-frame-wsshort-udp-esp-port-4500.pcap", "data": "", "results": {"tool": "ncapture", "version": "0.1.7"}}'
     body = body.encode('utf-8')
-    callback(ch, method, None, body)
+    callback(ch, method, None, body, workers_json=WORKERS_JSON)
 
     body = '{"id": "", "type": "data", "file_path": "/files/tcprewrite-dot1q-2019-12-31-17_33_32.961111-UTC/pcap-node-splitter-2019-12-31-17_34_17.314910-UTC/clients/trace_5c7820e51dbabbf0476097dda838c7eabfa8e160_2019-12-31_17_18_17-client-ip-38-103-36-98-192-168-0-46-38-103-36-98-eth-udpencap-ip-frame-wsshort-udp-esp-port-4500.pcap", "data": "", "results": {"tool": "p0f", "version": "0.1.7"}}'
     body = body.encode('utf-8')
-    callback(ch, method, None, body)
+    callback(ch, method, None, body, workers_json=WORKERS_JSON)
 
     body = '{"type": "data", "file_path": "/files/tcprewrite-dot1q-2019-12-31-17_33_32.961111-UTC/pcap-node-splitter-2019-12-31-17_34_17.314910-UTC/clients/trace_5c7820e51dbabbf0476097dda838c7eabfa8e160_2019-12-31_17_18_17-client-ip-38-103-36-98-192-168-0-46-38-103-36-98-eth-udpencap-ip-frame-wsshort-udp-esp-port-4500.pcap", "data": "", "results": {"tool": "p0f", "version": "0.1.7"}}'
     body = body.encode('utf-8')
-    callback(ch, method, None, body)
+    callback(ch, method, None, body, workers_json=WORKERS_JSON)
 
     body = '{"id": "", "type": "metadata", "file_path": "/files/tcprewrite-dot1q-2019-12-31-17_33_32.961111-UTC/pcap-node-splitter-2019-12-31-17_34_17.314910-UTC/clients/trace_5c7820e51dbabbf0476097dda838c7eabfa8e160_2019-12-31_17_18_17-client-ip-38-103-36-98-192-168-0-46-38-103-36-98-eth-udpencap-ip-frame-wsshort-udp-esp-port-4500.pcap", "data": "", "results": {"tool": "pcap-splitter", "version": "0.1.7"}}'
     body = body.encode('utf-8')
-    callback(ch, method, None, body)
+    callback(ch, method, None, body, workers_json=WORKERS_JSON)

--- a/workers/worker.py
+++ b/workers/worker.py
@@ -24,10 +24,10 @@ def set_status(r, status, extra_workers):
     return
 
 
-def callback(ch, method, properties, body):
+def callback(ch, method, properties, body, workers_json='workers.json'):
     """Callback that has the message that was received"""
     vol_prefix = os.getenv('VOL_PREFIX', '')
-    workers = load_workers()
+    workers = load_workers(workers_json)
     d = setup_docker()
     pipeline = json.loads(body.decode('utf-8'))
     worker_found = False
@@ -169,8 +169,8 @@ def setup_redis(host='redis', port=6379, db=0):
     return r
 
 
-def load_workers():
-    with open('workers.json') as json_file:
+def load_workers(workers_json='workers.json'):
+    with open(workers_json) as json_file:
         workers = json.load(json_file)
     return workers
 


### PR DESCRIPTION
… and fix test flakes due to temporary files in tests directory.

Incremental change to support stacking and centralized mirroring. Doesn't automatically add tunnel configuration yet, as depends on unreleased FAUCET changes.
